### PR TITLE
Add 'ping' command

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -1496,5 +1496,5 @@ func (a *Agent) SerfPing(name string) (*serfPingResponse, error) {
 		Success: cresp.Success,
 		RTT:     cresp.RTT,
 	}
-	return &resp, err
+	return &resp, nil
 }

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -1473,3 +1473,28 @@ func (a *Agent) SerfQuery(name string, payload []byte, params *serf.QueryParam) 
 	}
 	return resp, err
 }
+
+// SerfPing sends a Memberlist Ping via Serf.
+func (a *Agent) SerfPing(name string) (*serfPingResponse, error) {
+	a.logger.Printf("[DEBUG] agent: Requesting serf ping send: %s", name)
+	var err error
+	var cresp *consul.SerfPingResponse
+	params := consul.SerfPingParam{
+		Name: name,
+	}
+	if a.server != nil {
+		cresp, err = a.server.SerfPing(&params)
+	} else {
+		cresp, err = a.client.SerfPing(&params)
+	}
+	if err != nil {
+		a.logger.Printf("[WARN] agent: failed to start user serf ping: %v", err)
+		return nil, err
+	}
+
+	resp := serfPingResponse{
+		Success: cresp.Success,
+		RTT:     cresp.RTT,
+	}
+	return &resp, err
+}

--- a/command/agent/rpc_client.go
+++ b/command/agent/rpc_client.go
@@ -481,6 +481,29 @@ func (c *RPCClient) SerfQuery(params *consul.SerfQueryParam) error {
 	}
 }
 
+type serfPingRequest struct {
+	Name string
+}
+
+// SerfPing initiates a new ping message using the given parameters
+func (c *RPCClient) SerfPing(params *consul.SerfPingParam) (*serfPingResponse, error) {
+	// Setup the request
+	seq := c.getSeq()
+	header := requestHeader{
+		Command: serfPingCommand,
+		Seq:     seq,
+	}
+	req := serfPingRequest{
+		Name: params.Name,
+	}
+
+	var resp serfPingResponse
+	// Send the request
+	err := c.genericRPC(&header, &req, &resp)
+
+	return &resp, err
+}
+
 // Stop is used to unsubscribe from logs or event streams
 func (c *RPCClient) Stop(handle StreamHandle) error {
 	// Deregister locally first to stop delivery

--- a/command/ping.go
+++ b/command/ping.go
@@ -1,0 +1,108 @@
+package command
+
+import (
+	"flag"
+	"fmt"
+	"github.com/hashicorp/consul/consul"
+	"github.com/mitchellh/cli"
+	"os"
+	"os/signal"
+	"strings"
+	"time"
+)
+
+// PingCommand is a Command implementation that is used to initiate
+// a series of Serf 'ping' messages to the specified client node
+type PingCommand struct {
+	ShutdownCh <-chan struct{}
+	Ui         cli.Ui
+}
+
+func (c *PingCommand) Help() string {
+	helpText := `
+Usage: consul reachability [options]
+
+  Issues a series of Serf 'ping' messages to the specified node
+
+Options:
+
+  -rpc-addr=127.0.0.1:8400  RPC address of the Consul agent.
+  -count                    Number of pings to send (0 is infinite)
+  -node                     Name of node to ping
+`
+	return strings.TrimSpace(helpText)
+}
+
+func (c *PingCommand) Run(args []string) int {
+	var count int
+	var nodename string
+	exit := 0
+	cmdFlags := flag.NewFlagSet("ping", flag.ContinueOnError)
+	cmdFlags.Usage = func() { c.Ui.Output(c.Help()) }
+	cmdFlags.IntVar(&count, "count", 0, "count")
+	cmdFlags.StringVar(&nodename, "node", "*", "name of node to ping")
+	rpcAddr := RPCAddrFlag(cmdFlags)
+	if err := cmdFlags.Parse(args); err != nil {
+		return 1
+	}
+
+	cl, err := RPCClient(*rpcAddr)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error connecting to Consul agent: %s", err))
+		return 1
+	}
+	defer cl.Close()
+
+	success := 0
+	latency := 0 * time.Millisecond
+	var sent int
+	c.Ui.Output("Starting serf ping...")
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt)
+	go func() {
+		<-sigChan
+		cleanup(sent, success, latency, c)
+		os.Exit(exit)
+	}()
+	for sent = 0; (count == 0) || (sent < count); sent++ {
+		if sent > 0 {
+			time.Sleep(time.Second)
+		}
+		// Start the query
+		params := consul.SerfPingParam{
+			Name: nodename,
+		}
+		if resp, err := cl.SerfPing(&params); err != nil {
+			c.Ui.Error(fmt.Sprintf("Error sending serf ping: %s", err))
+			exit = 1
+			break
+		} else if resp.Success {
+			c.Ui.Output(fmt.Sprintf("Count %d: Node %s responded in %s", sent, nodename, resp.RTT))
+			latency = latency + resp.RTT
+			success++
+		} else {
+			c.Ui.Output(fmt.Sprintf("Count %d: Node %s failed to respond in %s", sent, nodename, resp.RTT))
+		}
+	}
+
+	if exit == 0 {
+		cleanup(sent, success, latency, c)
+	}
+
+	return exit
+}
+
+func cleanup(sent int, success int, latency time.Duration, c *PingCommand) {
+	var avgLatency string
+	if success > 0 {
+		avgLatency = fmt.Sprintf("%s", latency/time.Duration(success))
+	} else {
+		avgLatency = "N/A"
+	}
+	c.Ui.Output(fmt.Sprintf("Statistics: total %d, success %d%%, avg latency: %s",
+		sent, (success * 100 / sent), avgLatency))
+}
+
+func (c *PingCommand) Synopsis() string {
+	return "Issue Serf 'ping' messages to specified node"
+}

--- a/commands.go
+++ b/commands.go
@@ -108,6 +108,12 @@ func init() {
 			}, nil
 		},
 
+		"ping": func() (cli.Command, error) {
+			return &command.PingCommand{
+				Ui: ui,
+			}, nil
+		},
+
 		"reachability": func() (cli.Command, error) {
 			return &command.ReachabilityCommand{
 				Ui: ui,

--- a/consul/client.go
+++ b/consul/client.go
@@ -63,8 +63,8 @@ type Client struct {
 	// which contains all the DC nodes
 	serf *serf.Serf
 
-	// serfQuery is used to perform 'reachability' tests
-	serfQuery *SerfQuery
+	// serfDiag is used to perform Serf-based diagnostic tests
+	serfDiag *SerfDiag
 
 	shutdown     bool
 	shutdownCh   chan struct{}
@@ -123,11 +123,11 @@ func NewClient(config *Config) (*Client, error) {
 		return nil, fmt.Errorf("Failed to start lan serf: %v", err)
 	}
 
-	// Initialize the SerfQuery object
-	c.serfQuery, err = NewSerfQuery(config, c.serf)
+	// Initialize the SerfDiag object
+	c.serfDiag, err = NewSerfDiag(config, c.serf)
 	if err != nil {
 		c.Shutdown()
-		return nil, fmt.Errorf("Failed to initialize serfQuery: %v", err)
+		return nil, fmt.Errorf("Failed to initialize serfDiag: %v", err)
 	}
 
 	return c, nil
@@ -397,6 +397,11 @@ func (c *Client) GetCoordinate() (*coordinate.Coordinate, error) {
 }
 
 func (c *Client) SerfQuery(name string, payload []byte, params *serf.QueryParam) (*serf.QueryResponse, error) {
-	qr, err := c.serfQuery.Query(name, payload, params)
+	qr, err := c.serfDiag.Query(name, payload, params)
 	return qr, err
+}
+
+func (c *Client) SerfPing(param *SerfPingParam) (*SerfPingResponse, error) {
+	resp, err := c.serfDiag.Ping(param)
+	return resp, err
 }

--- a/website/source/docs/commands/index.html.markdown
+++ b/website/source/docs/commands/index.html.markdown
@@ -38,6 +38,7 @@ Available commands are:
     lock           Execute a command holding a lock
     members        Lists the members of a Consul cluster
     monitor        Stream logs from a Consul agent
+    ping           Issue Serf 'ping' messages to specified node
     reachability   Test network reachability
     reload         Triggers the agent to reload configuration files
     rtt            Estimates network round trip time between nodes

--- a/website/source/docs/commands/ping.html.markdown
+++ b/website/source/docs/commands/ping.html.markdown
@@ -1,0 +1,89 @@
+---
+layout: "docs"
+page_title: "Commands: Ping"
+sidebar_current: "docs-commands-ping"
+description: |-
+  The `ping` command issues Serf 'ping' messages to specified node and displays response statistics.
+---
+
+# Consul Ping
+
+Command: `consul ping`
+
+The `ping` command issues Serf 'ping' messages to the specified node.
+If a count is specified, the test will issue the specified number of
+packets to the node; if no count is specified, the test will continue
+indefinitely until interrupted by CTRL-C.  Once the test is finished
+(or interrupted), it displays statistics describing the number of
+packets sent, the number of responses received, the percentage of
+successful 'pings', and the average latency or round trip time of all
+successful responses.
+
+This can be used to troubleshoot configurations or network issues, since
+nodes that are having issues responding to UDP traffic will either
+intermittently respond or not respond at all.
+
+In general, the following troubleshooting tips are recommended:
+
+* Ensure that the bind addr:port is accessible by all other nodes
+* If an advertise address is set, ensure it routes to the bind address
+* Check that no nodes are behind a NAT
+* If nodes are behind firewalls or iptables, check that Serf traffic is permitted (UDP and TCP)
+* Verify networking equipment is functional
+
+## Usage
+
+Usage: `consul ping [options]`
+
+The following command-line options are available for this command.
+Every option is optional:
+
+* `-rpc-addr` - Address to the RPC server of the agent you want to contact
+  to send this command. If this isn't specified, the command will contact
+  "127.0.0.1:8400" which is the default RPC address of a Consul
+  agent. This option can also be controlled using the `CONSUL_RPC_ADDR`
+  environment variable.
+
+* `-node` - Name of the node to ping
+
+* `-count` - Number of pings to issue to target node.  If not
+  specified, continue issuing pings until interrupted by CTRL-C.
+
+## Output
+
+If the node exists in the data center, the specified number of ping
+messages will be sent and statistics displayed upon completion:
+
+```
+$ ./consul ping -node test-node-1 -count 5
+Starting serf ping...
+Count 0: Node test-node-1 responded in 785.244µs
+Count 1: Node test-node-1 responded in 871.454µs
+Count 2: Node test-node-1 responded in 714.955µs
+Count 3: Node test-node-1 responded in 6.008223ms
+Count 4: Node test-node-1 responded in 884.21µs
+Statistics: total 5, success 100%, avg latency: 1.852817ms
+```
+
+If the node does not respong to all packets, the output indicates the
+timeout value of ping messages for which no response was received:
+
+```
+$ ./consul ping -node test-node-5 -count 5
+Starting serf ping...
+Count 0: Node test-node-5 responded in 858.761µs
+Count 1: Node test-node-5 responded in 862.887µs
+Count 2: Node test-node-5 responded in 857.277µs
+Count 3: Node test-node-5 failed to respond in 500ms
+Count 4: Node test-node-5 responded in 953.343µs
+Statistics: total 5, success 80%, avg latency: 883.067µs
+```
+
+If the node is not a member of the data center, an error will be
+displayed:
+
+```
+$ ./consul ping -node nodeDoesNotExist
+Starting serf ping...
+Error sending serf ping: Member nodeDoesNotExist not found in data center.
+```

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -122,6 +122,10 @@
 					<a href="/docs/commands/info.html">info</a>
 					</li>
 
+					<li<%= sidebar_current("docs-commands-ping") %>>
+					<a href="/docs/commands/ping.html">ping</a>
+					</li>
+
 					<li<%= sidebar_current("docs-commands-reachability") %>>
 					<a href="/docs/commands/reachability.html">reachability</a>
 					</li>


### PR DESCRIPTION
To perform memberlist pings as a network diagnostic tool, add 'ping' CLI command, plumb through to the client and server, and then invoke the Memberlist.Ping() method.
